### PR TITLE
Podium demo - Use document template

### DIFF
--- a/8_podium/team-decide/package-lock.json
+++ b/8_podium/team-decide/package-lock.json
@@ -5,35 +5,35 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime-corejs2": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
-      "integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
+      "version": "7.7.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.6.tgz",
+      "integrity": "sha512-QYp/8xdH8iMin3pH5gtT/rUuttVfIcOhWBC3wh9Eh/qs4jEe39+3DpCDLgWXhMQgiCTOH8mrLSvQ0OHOCcox9g==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
       }
     },
     "@hapi/boom": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.3.tgz",
-      "integrity": "sha512-3di+R+BcGS7HKy67Zi6mIga8orf67GdR0ubDEVBG1oqz3y9B70LewsuCMCSvWWLKlI6V1+266zqhYzjMrPGvZw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-8.0.1.tgz",
+      "integrity": "sha512-SnBM2GzEYEA6AGFKXBqNLWXR3uNBui0bkmklYXX1gYtevVhDTy2uakwkSauxvIWMtlANGRhzChYg95If3FWCwA==",
       "requires": {
         "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/hoek": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz",
-      "integrity": "sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg=="
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
     },
     "@metrics/client": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@metrics/client/-/client-2.4.1.tgz",
-      "integrity": "sha512-kc5WOy2HD/+SbrG9jmqvDzetMZ22cgXJV/lvqwMQEd6XEOJcsUFyUz2ZEMwmyNfJq3BGPSUpCpzw+uM/CbTBKg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@metrics/client/-/client-2.5.0.tgz",
+      "integrity": "sha512-MBUKmW1d3esIlxhI4M3J5BaPnOIhC8M7hHcnzEJULHCgEvYDoOoAIgJNoJdRImgaj1SD2aGuZza1wDbniZDxCg==",
       "requires": {
         "@metrics/metric": "^2.3.1",
-        "readable-stream": "^3.2.0",
-        "time-span": "^3.0.0"
+        "readable-stream": "^3.4.0",
+        "time-span": "^3.1.0"
       }
     },
     "@metrics/metric": {
@@ -42,64 +42,64 @@
       "integrity": "sha512-r2AV5kqs5DrA2lJ6oxgt4HQa2WR1I/8B2TZr/ocH7J6yaSBw9xil9bJYibtABIu2qJx3LJGiW4fxFfifYWzlRA=="
     },
     "@podium/client": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@podium/client/-/client-4.1.0.tgz",
-      "integrity": "sha512-VOczohVqLYhkN7ehozLt9JkbDGLeFjOt2s36JZa/AakWIlMprVJds3o2L+VrWinhW+wVpxuiI6/93FDSwHjXGA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@podium/client/-/client-4.1.3.tgz",
+      "integrity": "sha512-IfD/sZ1Htx5lUFqIRoZfyiuF5NddtopZdMkUnOF4Fu/fcpwqM2w1O/mNefBlXMLevZqXZTEMvDwtNSFfF+5MOg==",
       "requires": {
-        "@hapi/boom": "^7.3.0",
-        "@metrics/client": "2.4.1",
+        "@hapi/boom": "^8.0.1",
+        "@metrics/client": "2.5.0",
         "@podium/schemas": "4.0.0",
-        "@podium/utils": "4.1.0",
+        "@podium/utils": "^4.1.2",
         "abslog": "2.4.0",
         "http-cache-semantics": "^4.0.3",
         "lodash.clonedeep": "^4.5.0",
-        "readable-stream": "^3.2.0",
+        "readable-stream": "^3.4.0",
         "request": "^2.88.0",
         "ttl-mem-cache": "4.1.0"
       }
     },
     "@podium/context": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@podium/context/-/context-4.0.1.tgz",
-      "integrity": "sha512-MkPk6unwqhX+6JV+Y7T7AqgwikRNeRNxx5cuf/UVTVFbIXFiNMWPgQQo959iuwIt9afMEgePl5ElD80ciSfWQg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@podium/context/-/context-4.0.4.tgz",
+      "integrity": "sha512-0P1B3kkADMF6BhDnWneM6O9MELSfsv30gMpUtjNwVvEPOTG+8sPOdu03A/wJ6ZUL0kZN0U2lNhx4UnXux8loLQ==",
       "requires": {
-        "@metrics/client": "2.4.1",
+        "@metrics/client": "2.5.0",
         "@podium/schemas": "4.0.0",
-        "@podium/utils": "4.1.0",
+        "@podium/utils": "^4.1.2",
         "abslog": "^2.4.0",
         "bcp47-validate": "^1.0.0",
-        "bowser": "^2.5.3",
-        "decamelize": "^3.1.1",
+        "bowser": "^2.7.0",
+        "decamelize": "^3.2.0",
         "lru-cache": "^5.1.1"
       }
     },
     "@podium/layout": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@podium/layout/-/layout-4.2.0.tgz",
-      "integrity": "sha512-7ON8RiLf9BMgsZsfju2ryJwEamU52PN36XKqzcc6gSGLzWs7jU6+KnktalxhE9gbx6OoeM+SXDUk48zVFT9Ixg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@podium/layout/-/layout-4.2.7.tgz",
+      "integrity": "sha512-r0gwr04cw5t1777jfn9wnl6D1UzsyLcNDEfcpy7q3CSCYzV8ZzXlLv5O+SwoowdaBeF/GFwlxoB9ZvS01VJYIg==",
       "requires": {
-        "@metrics/client": "2.4.1",
-        "@podium/client": "4.1.0",
-        "@podium/context": "4.0.1",
-        "@podium/proxy": "4.0.2",
+        "@metrics/client": "2.5.0",
+        "@podium/client": "4.1.3",
+        "@podium/context": "4.0.4",
+        "@podium/proxy": "4.0.6",
         "@podium/schemas": "4.0.0",
-        "@podium/utils": "4.1.0",
+        "@podium/utils": "4.1.2",
         "abslog": "2.4.0",
         "lodash.merge": "4.6.2",
         "objobj": "1.0.0"
       }
     },
     "@podium/proxy": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@podium/proxy/-/proxy-4.0.2.tgz",
-      "integrity": "sha512-1F4tKi+sjTsX69Pz/yYPjhOl2t6cBMhB85EawJHOL5BZTzVVA6mrh5YFQCZj0jkvK2D2kK/CiQIh5wPbPiqk5w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@podium/proxy/-/proxy-4.0.6.tgz",
+      "integrity": "sha512-3RXS2XdLTLqN1wcrPmf47VS4lO13x52JnpYw0LcrADlVGOh6bioZmA3S139REa0IK58JG3ivzq/D2at31q8GQw==",
       "requires": {
-        "@metrics/client": "2.4.1",
+        "@metrics/client": "2.5.0",
         "@podium/schemas": "4.0.0",
-        "@podium/utils": "4.1.0",
+        "@podium/utils": "^4.1.2",
         "abslog": "2.4.0",
-        "http-proxy": "1.17.0",
-        "path-to-regexp": "3.0.0",
+        "http-proxy": "1.18.0",
+        "path-to-regexp": "6.1.0",
         "ttl-mem-cache": "4.1.0"
       }
     },
@@ -112,13 +112,13 @@
       }
     },
     "@podium/utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@podium/utils/-/utils-4.1.0.tgz",
-      "integrity": "sha512-wadwDSvOhRGN/x1SgDxm6C44gEq+ipGsJfo6vUd5cAWDOhDevDofP8G1GOg34tJpv0W7ctyZ2+PK+TjeUXrFRA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@podium/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-5RIA+I85LU3Z/V4wRkiURY82VFONUKhVrwIBQJBs7EenQF3bGnmBT7NW2DwagkYREcQZ1fTyKs5tDiprI7yISA==",
       "requires": {
         "@podium/schemas": "4.0.0",
-        "camelcase": "^5.3.0",
-        "original-url": "^1.2.1"
+        "camelcase": "^5.3.1",
+        "original-url": "^1.2.3"
       }
     },
     "abslog": {
@@ -178,9 +178,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -248,9 +248,9 @@
       }
     },
     "bowser": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.5.3.tgz",
-      "integrity": "sha512-aWCA+CKfKNL/WGzNgjmK+Whp57JMzboZMwJ5gy2jDj2bEIjbMCb3ImGX+V++5wsJftyFiDIbOjRXl60ycniVqg=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.7.0.tgz",
+      "integrity": "sha512-aIlMvstvu8x+34KEiOHD3AsBgdrzg6sxALYiukOWhFvGMbQI6TRP/iY0LMhUrHs56aD6P1G0Z7h45PUJaa5m9w=="
     },
     "bytes": {
       "version": "3.1.0",
@@ -311,9 +311,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -389,9 +389,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
     },
     "express": {
       "version": "4.17.1",
@@ -476,9 +476,9 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -510,11 +510,11 @@
       }
     },
     "follow-redirects": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
-      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+      "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
       "requires": {
-        "debug": "^3.2.6"
+        "debug": "^3.0.0"
       }
     },
     "forever-agent": {
@@ -594,11 +594,11 @@
       }
     },
     "http-proxy": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
-      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
       "requires": {
-        "eventemitter3": "^3.0.0",
+        "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
       }
@@ -802,9 +802,9 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "path-to-regexp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.0.0.tgz",
-      "integrity": "sha512-ZOtfhPttCrqp2M1PBBH4X13XlvnfhIwD7yCLx+GoGoXRPQyxGOTdQMpIzPSPKXAJT/JQrdfFrgdJOyAzvgpQ9A=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
+      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw=="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -821,9 +821,9 @@
       }
     },
     "psl": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
-      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
+      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -1106,9 +1106,9 @@
       }
     },
     "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     }
   }
 }

--- a/8_podium/team-decide/package.json
+++ b/8_podium/team-decide/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@podium/layout": "^4.2.0",
+    "@podium/layout": "^4.2.7",
     "express": "^4.17.1",
     "morgan": "^1.9.1"
   }

--- a/8_podium/team-inspire/index.js
+++ b/8_podium/team-inspire/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const express = require("express");
 const morgan = require("morgan");
 const Podlet = require("@podium/podlet");
@@ -6,8 +8,10 @@ const podlet = new Podlet({
   name: "recos",
   version: "1.0.2",
   pathname: "/recos",
-  fallback: "/fallback"
+  fallback: "/fallback",
+  development: true,
 });
+
 podlet.css({
   value: "http://localhost:3002/static/fragment.css"
 });

--- a/8_podium/team-inspire/package-lock.json
+++ b/8_podium/team-inspire/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "dependencies": {
     "@metrics/client": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@metrics/client/-/client-2.4.1.tgz",
-      "integrity": "sha512-kc5WOy2HD/+SbrG9jmqvDzetMZ22cgXJV/lvqwMQEd6XEOJcsUFyUz2ZEMwmyNfJq3BGPSUpCpzw+uM/CbTBKg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@metrics/client/-/client-2.5.0.tgz",
+      "integrity": "sha512-MBUKmW1d3esIlxhI4M3J5BaPnOIhC8M7hHcnzEJULHCgEvYDoOoAIgJNoJdRImgaj1SD2aGuZza1wDbniZDxCg==",
       "requires": {
         "@metrics/metric": "^2.3.1",
-        "readable-stream": "^3.2.0",
-        "time-span": "^3.0.0"
+        "readable-stream": "^3.4.0",
+        "time-span": "^3.1.0"
       }
     },
     "@metrics/metric": {
@@ -20,29 +20,29 @@
       "integrity": "sha512-r2AV5kqs5DrA2lJ6oxgt4HQa2WR1I/8B2TZr/ocH7J6yaSBw9xil9bJYibtABIu2qJx3LJGiW4fxFfifYWzlRA=="
     },
     "@podium/podlet": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@podium/podlet/-/podlet-4.2.0.tgz",
-      "integrity": "sha512-EudQQzKedOcZV1xAt/dKfsgPo4ey1nIVdCcI95jcYUGkdcGVrBw1iM6BKBwHnTts/CTFwAN1ZUv7pGRwRkX9kA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@podium/podlet/-/podlet-4.2.4.tgz",
+      "integrity": "sha512-CpNvVT14hl3eT0Yg1sc2yqG0Jp8fQMSbvPYTP+3y7YXzpVCOW5U5l5Wqy4NaZNIlXhgNtRAfxkX8JM1Y2hJ3AA==",
       "requires": {
-        "@metrics/client": "2.4.1",
-        "@podium/proxy": "4.0.2",
+        "@metrics/client": "2.5.0",
+        "@podium/proxy": "4.0.5",
         "@podium/schemas": "4.0.0",
-        "@podium/utils": "4.1.0",
+        "@podium/utils": "4.1.2",
         "abslog": "2.4.0",
         "objobj": "^1.0.0"
       }
     },
     "@podium/proxy": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@podium/proxy/-/proxy-4.0.2.tgz",
-      "integrity": "sha512-1F4tKi+sjTsX69Pz/yYPjhOl2t6cBMhB85EawJHOL5BZTzVVA6mrh5YFQCZj0jkvK2D2kK/CiQIh5wPbPiqk5w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@podium/proxy/-/proxy-4.0.5.tgz",
+      "integrity": "sha512-6a0jy+hKbZZI8p7TJldBkp6pkoSGBbzLM1Qy2IPp1C6k+RQm5KjTlVTd6j3al3IAMCD842GfnKSNEQvKvUmnYw==",
       "requires": {
-        "@metrics/client": "2.4.1",
+        "@metrics/client": "2.5.0",
         "@podium/schemas": "4.0.0",
-        "@podium/utils": "4.1.0",
+        "@podium/utils": "^4.1.2",
         "abslog": "2.4.0",
-        "http-proxy": "1.17.0",
-        "path-to-regexp": "3.0.0",
+        "http-proxy": "1.18.0",
+        "path-to-regexp": "5.0.0",
         "ttl-mem-cache": "4.1.0"
       }
     },
@@ -55,13 +55,13 @@
       }
     },
     "@podium/utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@podium/utils/-/utils-4.1.0.tgz",
-      "integrity": "sha512-wadwDSvOhRGN/x1SgDxm6C44gEq+ipGsJfo6vUd5cAWDOhDevDofP8G1GOg34tJpv0W7ctyZ2+PK+TjeUXrFRA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@podium/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-5RIA+I85LU3Z/V4wRkiURY82VFONUKhVrwIBQJBs7EenQF3bGnmBT7NW2DwagkYREcQZ1fTyKs5tDiprI7yISA==",
       "requires": {
         "@podium/schemas": "4.0.0",
-        "camelcase": "^5.3.0",
-        "original-url": "^1.2.1"
+        "camelcase": "^5.3.1",
+        "original-url": "^1.2.3"
       }
     },
     "abslog": {
@@ -228,9 +228,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
     },
     "express": {
       "version": "4.17.1",
@@ -300,9 +300,9 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -334,11 +334,11 @@
       }
     },
     "follow-redirects": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
-      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+      "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
       "requires": {
-        "debug": "^3.2.6"
+        "debug": "^3.0.0"
       }
     },
     "forwarded": {
@@ -376,11 +376,11 @@
       }
     },
     "http-proxy": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
-      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
       "requires": {
-        "eventemitter3": "^3.0.0",
+        "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
       }
@@ -515,9 +515,9 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "path-to-regexp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.0.0.tgz",
-      "integrity": "sha512-ZOtfhPttCrqp2M1PBBH4X13XlvnfhIwD7yCLx+GoGoXRPQyxGOTdQMpIzPSPKXAJT/JQrdfFrgdJOyAzvgpQ9A=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-5.0.0.tgz",
+      "integrity": "sha512-VOQVA+0mivusQfaveeWlrW7ddXKuStHMTdovn/1epf7cEpUL4dpzGl7eq8ho96H9w90/q66yJLsqn84jSCfkmQ=="
     },
     "proxy-addr": {
       "version": "2.0.5",

--- a/8_podium/team-inspire/package.json
+++ b/8_podium/team-inspire/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@podium/podlet": "^4.2.0",
+    "@podium/podlet": "^4.2.4",
     "express": "^4.17.1",
     "morgan": "^1.9.1"
   }


### PR DESCRIPTION
Podium has a concept of a [document template](https://podium-lib.io/docs/api/document). A document template is normally the markup which encapsulates a podlet and a layout and looks something like this:

```html
<html>
  <head><title>My title</title></head>
  <body>
    <!-- Podlet / layout content goes here -->
  </body>
</html>
```

This concept is there to help development of Podlets withing the same constraints as it will be included in in a Layout. 

Lets say that in an organization all pages should have a CSS `class` on the `<body>` tag. Then all Layouts should have this and one would also like to have this in development when developing Podlets.

With this document template concept one can then make a node.js module which contains a such a document where the  `<body>` tag has such a CSS `class`. All Layouts and Podlets in an organization can then include this module as a dependency to their project and they will all be withing the constraints of this document template.

Podium does ship with a [basic document template](https://github.com/podium-lib/utils/blob/master/lib/html-document.js). This PR makes use of this default document template.